### PR TITLE
chore: pnpm 버전명시, corepack enable 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"main": "src/index.ts",
 	"scripts": {
 		"build": "tsup",
-		"start": "node dist/index.js"
+		"start": "node dist/index.js",
+		"preinstall": "corepack enable"
 	},
 	"repository": {
 		"type": "git",
@@ -14,6 +15,7 @@
 	"bin": {
 		"coauthors-cli": "./dist/index.js"
 	},
+	"packageManager": "pnpm@8.15.2",
 	"keywords": ["github", "co-authoring", "git", "collaboration", "cli"],
 	"author": "2-NOW <kj109888@gmail.com>",
 	"license": "ISC",


### PR DESCRIPTION
pnpm 안 쓰는 사람들을 위해 corepack 설정을 preinstall 에 추가했습니다.
또한, pnpm 버전이 달라서 lock 파일이 수정되는 경우를 막기 위해 packageManager 버전 명시를 했습니다.