### PR TITLE
Add Visualization Feature to console.log

### DIFF
--- a/.changeset/lucky-turkeys-sin.md
+++ b/.changeset/lucky-turkeys-sin.md
@@ -1,0 +1,5 @@
+---
+"coauthors": patch
+---
+
+Add Visualization Feature to console.log

--- a/.changeset/lucky-turkeys-sin.md
+++ b/.changeset/lucky-turkeys-sin.md
@@ -1,5 +1,5 @@
 ---
-"coauthors": patch
+"coauthors": minor
 ---
 
-Add Visualization Feature to console.log
+feat(coauthors): colorize terminal display

--- a/packages/coauthors/src/utils/log.ts
+++ b/packages/coauthors/src/utils/log.ts
@@ -1,12 +1,16 @@
 const verbose = process.argv.find((arg) => arg === "--verbose");
 const quietLog = process.argv.find((arg) => arg === "--quiet");
 
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const RESET = "\x1b[0m";
+
 export function debug(message: string): void {
   if (!verbose) {
     return;
   }
 
-  console.log(`coauthors > DEBUG: ${message}`);
+  console.log(`${YELLOW}coauthors >${RESET} DEBUG: ${message}`);
 }
 
 export function log(message: string): void {
@@ -14,5 +18,9 @@ export function log(message: string): void {
     return;
   }
 
-  console.log(`coauthors > ${message}`);
+  console.log(`${YELLOW}coauthors >${RESET} ${message}${RESET}`);
+}
+
+export function error(message: string): void {
+  console.error(`${YELLOW}coauthors > ${RED}ERROR - ${message}${RESET}`);
 }

--- a/packages/coauthors/src/utils/prepareCommitMsg.ts
+++ b/packages/coauthors/src/utils/prepareCommitMsg.ts
@@ -1,20 +1,29 @@
 import fs from "node:fs";
 import path from "node:path";
+import { exit } from "node:process";
 import { convert } from "./convert";
-import { log } from "./log";
+import { error, log } from "./log";
 
 export const prepareCommitMsg = async () => {
-  log("start");
-  const cwd = process.cwd();
-  log(`Resolving .git path from ${cwd}`);
-  let gitRootPath = path.resolve(cwd, "");
-  if (!gitRootPath.includes(".git")) {
-    gitRootPath = path.join(gitRootPath, ".git");
+  try {
+    log("start");
+    const cwd = process.cwd();
+    log(`Resolving .git path from ${cwd}`);
+    let gitRootPath = path.resolve(cwd, "");
+    if (!gitRootPath.includes(".git")) {
+      gitRootPath = path.join(gitRootPath, ".git");
+    }
+    const commitEditMsgPath = path.join(gitRootPath, "COMMIT_EDITMSG");
+    const message = fs.readFileSync(commitEditMsgPath, { encoding: "utf-8" });
+    const converted = await convert(message);
+    fs.writeFileSync(commitEditMsgPath, converted.result, {
+      encoding: "utf-8",
+    });
+    log("done");
+  } catch (_error) {
+    if (_error instanceof Error) {
+      error(_error.message);
+      exit(1);
+    }
   }
-  const commitEditMsgPath = path.join(gitRootPath, "COMMIT_EDITMSG");
-  const message = fs.readFileSync(commitEditMsgPath, { encoding: "utf-8" });
-  const converted = await convert(message);
-  fs.writeFileSync(commitEditMsgPath, converted.result, { encoding: "utf-8" });
-
-  log("done");
 };


### PR DESCRIPTION
# Overview

Hello. I have some suggestions to make regarding the use of the service.

## Features

- Modify the existing Log to add color to make it more noticeable
- Add error log

## Expected Effects

- Clarity of error messages, ease of integration with logging systems: After the change, error messages can be clearly distinguished through the prefix coauthors > ERROR:. This helps users reading the logs to easily differentiate between regular logs and error logs. It also makes it more suitable for integration with external logging systems (e.g., ELK stack, Splunk, etc.). A clear identifier for error logs (coauthors > ERROR:) makes it easier to automate log analysis and filter specific types of logs.

- Ease of debugging: Before the change, when an error occurred, the entire stack trace was printed, requiring going through a lot of information to find the actual error message. After the change, only the relevant error message is succinctly printed, allowing for quicker identification of the problem's cause.


I would appreciate your opinion on this simple feature addition. Have a good day.


## as-is

- error case
```shell
coauthors > start
coauthors > Resolving .git path from /test
node:fs:453
    return binding.readFileUtf8(path, stringToFlags(options.flag));
                   ^
Error: ENOENT: no such file or directory, open 'C:\test\.git\COMMIT_EDITMSG'
    at Object.readFileSync (node:fs:453:20)
    at C:\Users\alstj\OneDrive\Desktop\coauthors\packages\coauthors\dist\index.js:163:42
    at Generator.next (<anonymous>)
    at C:\Users\alstj\OneDrive\Desktop\coauthors\packages\coauthors\dist\index.js:42:61
    at new Promise (<anonymous>)
    at __async (C:\Users\alstj\OneDrive\Desktop\coauthors\packages\coauthors\dist\index.js:26:10)
    at prepareCommitMsg (C:\Users\alstj\OneDrive\Desktop\coauthors\packages\coauthors\dist\index.js:154:30)
    at Object.<anonymous> (C:\Users\alstj\OneDrive\Desktop\coauthors\packages\coauthors\dist\index.js:184:3)
    at Generator.next (<anonymous>)
    at C:\Users\alstj\OneDrive\Desktop\coauthors\packages\coauthors\dist\index.js:42:61 {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'C:\\test\\.git\\COMMIT_EDITMSG'
}
```

## to-be
![image](https://github.com/coauthors/coauthors/assets/60251579/9864772d-c827-46bd-8e90-d8cb0114bcc5)


## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/coauthors/coauthors/blob/main/CONTRIBUTING.md)
2. I added documents and tests. ( #51 ) 
